### PR TITLE
Add create-react-context to support < 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,8 @@
     "Dan Abramov <dan.abramov@me.com> (http://github.com/gaearon)",
     "Louis DeScioli <louis.descioli@gmail.com>"
   ],
-  "peerDependencies": {
-    "react": ">=16.3"
-  },
   "dependencies": {
+    "create-react-context": "^0.2.3",
     "exenv": "^1.2.2",
     "hoist-non-react-statics": "^3.0.1",
     "prop-types": "^15.6.2",

--- a/src/createSideEffect.js
+++ b/src/createSideEffect.js
@@ -1,11 +1,12 @@
 import React from "react";
 import { createStore, applyMiddleware } from "redux";
+import createReactContext from "create-react-context";
 
 import rootReducer from "./modules";
 import createProvider from "./createProvider";
 import createConsumer from "./createConsumer";
 
-const createContext = React.createContext;
+const createContext = React.createContext || createReactContext;
 
 export default function createSideEffect(
   reducePropsToState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,6 +1393,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+create-react-context@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -1932,6 +1939,18 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -2209,6 +2228,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@^5.0.0:
   version "5.0.0"
@@ -4502,7 +4525,7 @@ type-detect@^4.0.0:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
-ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 


### PR DESCRIPTION
Since react-safety-helmet still depends on old react, use create-react-context as a polyfill at present. 